### PR TITLE
Support JP text consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Supports the editing of Final Fantasy VI Save files for both Pixel Remastered and Super NES (.srm) as well as save state files created by the emulator ZSNES.
 
 See the latest release here: https://github.com/KiameV/final-fantasy-vi-save-editor/releases/latest
+
+Modifications by Yakaru Dezaki to (hackily) support Japanese save games

--- a/io/pr/loader.go
+++ b/io/pr/loader.go
@@ -12,7 +12,6 @@ import (
 	"ffvi_editor/models/consts/pr"
 	pri "ffvi_editor/models/pr"
 	"fmt"
-	jo "gitlab.com/c0b/go-ordered-json"
 	io "io"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	jo "gitlab.com/c0b/go-ordered-json"
 )
 
 func (p *PR) Load(fileName string) (err error) {
@@ -950,7 +951,7 @@ func (p *PR) execLoad(fileName string, omitFirstBytes bool) ([]byte, error) {
 	}
 
 	path := strings.ReplaceAll(filepath.Join(global.PWD, "pr_io"), "\\", "/")
-	cmd := exec.Command("cmd", "/C", "./pr_io.exe", "deobfuscateFile", `'`+fileName+`'`, s)
+	cmd := exec.Command("cmd", "/C", "./pr_io.exe", "deobfuscateFile", fileName, s)
 	cmd.Dir = path
 	cmd.Run()
 	return os.ReadFile("./pr_io/temp.txt")

--- a/io/pr/loader.go
+++ b/io/pr/loader.go
@@ -951,7 +951,7 @@ func (p *PR) execLoad(fileName string, omitFirstBytes bool) ([]byte, error) {
 	}
 
 	path := strings.ReplaceAll(filepath.Join(global.PWD, "pr_io"), "\\", "/")
-	cmd := exec.Command("cmd", "/C", "./pr_io.exe", "deobfuscateFile", fileName, s)
+	cmd := exec.Command("cmd", "/C", "pr_io.exe", "deobfuscateFile", fileName, s)
 	cmd.Dir = path
 	cmd.Run()
 	return os.ReadFile("./pr_io/temp.txt")


### PR DESCRIPTION
This change when used with the new PR_IO consumes the temporary text file in order to get a straightforward UTF8 input. This means a lot of the processing work can be removed (commented out in my changes since my goal was functionality first).
This allows the files to be loaded, edited, and saved. The UI, however, doesn't support Japanese so you will get "unknown symbol" squares, but better than failing outright!